### PR TITLE
open-browser.cabal: rename 'example' binary to less generic 'open-browser-example'

### DIFF
--- a/open-browser.cabal
+++ b/open-browser.cabal
@@ -30,7 +30,7 @@ library
       build-depends:        Win32
       other-modules:        Web.Browser.Windows
 
-executable example
+executable open-browser-example
     main-is:                Main.hs
     hs-source-dirs:         example
     default-language:       Haskell2010


### PR DESCRIPTION
Renamed executable to be less prone to binary name clash when installed systemwide.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>